### PR TITLE
change how to get record

### DIFF
--- a/common/db/event.ts
+++ b/common/db/event.ts
@@ -50,7 +50,6 @@ export async function getEventRecord<Entity>(
 		.createQueryBuilder('tmp')
 		.where('tmp.block_number >= :_blockNumber', { _blockNumber: blockNumber })
 		.orderBy('tmp.block_number')
-		.take(10)
 		.getMany()
 
 	return records

--- a/property-authentication/index.ts
+++ b/property-authentication/index.ts
@@ -29,7 +29,7 @@ const timerTrigger: AzureFunction = async function (
 	await db.connect()
 
 	try {
-		await createPropertyAuthenticationRecord(db.connection)
+		await createPropertyAuthenticationRecord(db.connection, logging)
 	} catch (e) {
 		context.log.error(e.stack)
 		await logging.error(e.message)
@@ -42,7 +42,8 @@ const timerTrigger: AzureFunction = async function (
 }
 
 async function createPropertyAuthenticationRecord(
-	con: Connection
+	con: Connection,
+	logging: EventSaverLogging
 ): Promise<void> {
 	const blockNumber = await getMaxBlockNumber(con, PropertyAuthentication)
 	const records = await getEventRecord(
@@ -78,6 +79,7 @@ async function createPropertyAuthenticationRecord(
 		}
 
 		await transaction.commit()
+		await logging.info(`record wa inserted：${records.length}`)
 	} catch (e) {
 		await transaction.rollback()
 		throw e


### PR DESCRIPTION
Description
Eliminated the limit on the number of records retrieved.

Why
To prevent processing records from leaking
