### PR TITLE
return raw data

### DIFF
--- a/graphql/hasura-api.ts
+++ b/graphql/hasura-api.ts
@@ -61,6 +61,10 @@ abstract class HasuraApiExecuter implements ApiExecuter {
 				},
 				{
 					headers: this.getPostHeader(),
+					transformResponse: (res) => {
+						return res
+					},
+					responseType: 'json',
 				}
 			)
 		} catch (e) {


### PR DESCRIPTION
Description
When working with large numbers, I stopped parsing them and started returning the raw data.

Why
Because the numbers would be rounded up.

