### PR TITLE
Added `no-store` to cache-control

### DIFF
--- a/graphql/hasura-api.ts
+++ b/graphql/hasura-api.ts
@@ -8,7 +8,7 @@ import { isNotEmpty } from '../common/utils'
 import { RequestValidatorBuilder, ValidateError } from './validator'
 
 interface ApiExecuter {
-	execute(): Promise<any>
+	execute: () => Promise<any>
 }
 
 abstract class HasuraApiExecuter implements ApiExecuter {

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -11,6 +11,9 @@ const httpTrigger: AzureFunction = async function (
 	context.res = {
 		status: res.status,
 		body: res.body,
+		headers: {
+			'Cache-Control': 'no-store',
+		},
 	}
 }
 

--- a/graphql/validator.ts
+++ b/graphql/validator.ts
@@ -55,7 +55,7 @@ export class ValidateError extends Error {
 }
 
 interface Validator {
-	execute(req: HttpRequest): void
+	execute: (req: HttpRequest) => void
 }
 
 class JsonValidator implements Validator {


### PR DESCRIPTION
# Description

I added `no-store` to cache-control.

# Why

Even if Hasura is updated, the API responses may return outdated data.

Referring to GitHub GraphQL API, it seems that a suitable caching strategy is "don't cache."

# Related Issues

Fixes # .
