### PR TITLE
update colmn name

### DIFF
--- a/entities/reward-calculation-result.ts
+++ b/entities/reward-calculation-result.ts
@@ -4,7 +4,7 @@ import { Entity, PrimaryColumn, Column, BaseEntity } from 'typeorm'
 @Entity()
 export class RewardCalculationResult extends BaseEntity {
 	@PrimaryColumn()
-	public alocator_allocation_result_event_id!: string
+	public event_id!: string
 
 	@Column()
 	public block_number!: number

--- a/local_test/db/docker/db/init/12_reward_calculation_result.sql
+++ b/local_test/db/docker/db/init/12_reward_calculation_result.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS reward_calculation_result;
 
 CREATE TABLE reward_calculation_result(
-    alocator_allocation_result_event_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
     block_number INT NOT NULL,
     metrics TEXT NOT NULL,
     lockup NUMERIC NOT NULL,
@@ -9,7 +9,7 @@ CREATE TABLE reward_calculation_result(
     holder_reward NUMERIC NOT NULL,
     staking_reward NUMERIC NOT NULL,
     policy TEXT NOT NULL,
-    PRIMARY KEY(alocator_allocation_result_event_id)
+    PRIMARY KEY(event_id)
 );
 
 
@@ -18,7 +18,7 @@ CREATE INDEX ON reward_calculation_result(
 );
 
 COMMENT ON TABLE reward_calculation_result IS 'the results of the reward calculation.';
-COMMENT ON COLUMN reward_calculation_result.alocator_allocation_result_event_id IS 'the event id of the result of the allocate execution';
+COMMENT ON COLUMN reward_calculation_result.event_id IS 'the event id of the result of the allocate execution';
 COMMENT ON COLUMN reward_calculation_result.block_number IS 'block number at the time of allocate';
 COMMENT ON COLUMN reward_calculation_result.metrics IS 'the metrics address specified at the time of allocate';
 COMMENT ON COLUMN reward_calculation_result.lockup IS 'lockup value per property';

--- a/reward-calculation-result/index.ts
+++ b/reward-calculation-result/index.ts
@@ -60,7 +60,7 @@ class RewardCalculationer extends TimerBatchBase {
 
 			for (let record of targetRecords) {
 				const insertRecord = new RewardCalculationResult()
-				insertRecord.alocator_allocation_result_event_id = record.event_id
+				insertRecord.event_id = record.event_id
 				insertRecord.block_number = record.block_number
 				insertRecord.metrics = record.metrics
 				insertRecord.lockup = record.lockup_value

--- a/test/main/reward-calculation-result/index.ts
+++ b/test/main/reward-calculation-result/index.ts
@@ -69,9 +69,9 @@ describe('timerTrigger', () => {
 		expect(count).toBe(1)
 		const repository = con.connection.getRepository(RewardCalculationResult)
 		const record = await repository.findOne({
-			alocator_allocation_result_event_id: 'dummy-event-id1',
+			event_id: 'dummy-event-id1',
 		})
-		expect(record.alocator_allocation_result_event_id).toBe('dummy-event-id1')
+		expect(record.event_id).toBe('dummy-event-id1')
 		expect(record.block_number).toBe(30000)
 		expect(record.metrics).toBe('dummy-metrics-address1')
 		expect(Number(record.lockup)).toBe(10)


### PR DESCRIPTION
# Description

update colmn name
alocator_allocation_result_event_id->event_id

# Why

The name of the column was too long.
(After that, I made a typo.)

# Related Issues

Fixes #123

# supplement
Execute this SQL before deploying

ALTER TABLE reward_calculation_result RENAME alocator_allocation_result_event_id to event_id;
