### PR TITLE
trim query

### DIFF
--- a/graphql/validator.ts
+++ b/graphql/validator.ts
@@ -81,7 +81,7 @@ class QueryValidator implements Validator {
 
 class SchemaQueryValidator implements Validator {
 	public execute(req: HttpRequest): void {
-		if (req.body.query.startsWith('query IntrospectionQuery')) {
+		if (req.body.query.trim().startsWith('query IntrospectionQuery')) {
 			return
 		}
 

--- a/local.settings.json
+++ b/local.settings.json
@@ -17,5 +17,8 @@
 		"HASERA_ROLE": "",
 		"HASURA_SECRET": "",
 		"ENTITIES": "dist/entities/*.js"
+	},
+	"Host": {
+		"CORS": "*"
 	}
 }


### PR DESCRIPTION
# Description

When you run a query to get schema information, you trim the query.

# Why

Because there's an error in the validator.

# Related Issues

Fixes #127 
